### PR TITLE
WIP: Replace all mentions of `Rubocop` and `cop` with `RbHint` and `hint` in basic_usage.adoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby]())
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
 
@@ -4585,3 +4586,4 @@
 [@ric2b]: https://github.com/ric2b
 [@burnettk]: https://github.com/burnettk
 [@andrykonchin]: https://github.com/andrykonchin
+[@jdruby]: https://github.com/jdruby

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -230,12 +230,12 @@ $ rbhint -h
 | Displays the current version plus the version of Parser and Ruby.
 |===
 
-Default command-line options are loaded from `.rubocop.yml` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rbhint`.
+Default command-line options are loaded from `.rubocop` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rbhint`.
 Thus, the options have the following order of precedence (from highest to lowest):
 
 . Explicit command-line options
 . Options from `RUBOCOP_OPTS` environment variable
-. Options from `.rubocop.yml` file.
+. Options from `.rubocop` file.
 
 == Exit codes
 

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -1,6 +1,6 @@
 = Basic Usage
 
-RuboCop has three primary uses:
+RbHint has three primary uses:
 
 . Code style checker (a.k.a. linter)
 . A replacement for `ruby -w` (a subset of its linting capabilities)
@@ -10,22 +10,22 @@ In the next sections we'll briefly cover all of them.
 
 == 1. Code style checker
 
-Running `rubocop` with no arguments will check all Ruby source files
+Running `rbhint` with no arguments will check all Ruby source files
 in the current directory:
 
 [source,sh]
 ----
-$ rubocop
+$ rbhint
 ----
 
-Alternatively you can pass `rubocop` a list of files and directories to check:
+Alternatively you can pass `rbhint` a list of files and directories to check:
 
 [source,sh]
 ----
-$ rubocop app spec lib/something.rb
+$ rbhint app spec lib/something.rb
 ----
 
-Here's RuboCop in action. Consider the following Ruby source code:
+Here's RbHint in action. Consider the following Ruby source code:
 
 [source,ruby]
 ----
@@ -36,7 +36,7 @@ def badName
 end
 ----
 
-Running RuboCop on it (assuming it's in a file named `test.rb`) would produce the following report:
+Running RbHint on it (assuming it's in a file named `test.rb`) would produce the following report:
 
 ----
 Inspecting 1 file
@@ -65,46 +65,46 @@ test.rb:4:5: W: Layout/EndAlignment: end at 4, 4 is not aligned with if at 2, 2.
 
 === Auto-correcting offenses
 
-You can also run RuboCop in an auto-correct mode, where it will try to
+You can also run RbHint in an auto-correct mode, where it will try to
 automatically fix the problems it found in your code:
 
 [source,sh]
 ----
-$ rubocop -a
+$ rbhint -a
 ----
 
 See xref:usage/auto_correct.adoc[Auto-correct].
 
-=== Changing what RuboCop considers to be offenses
+=== Changing what RbHint considers to be offenses
 
-RuboCop comes with a preconfigured set of rules for each of its cops, based on the https://rubystyle.guide[Ruby Style Guide].
-Depending on your project, you may wish to reconfigure a cop, tell to ignore certain files, or disable it altogether.
+RbHint comes with a preconfigured set of rules for each of its hints, based on the https://rubystyle.guide[Ruby Style Guide].
+Depending on your project, you may wish to reconfigure a hint, tell to ignore certain files, or disable it altogether.
 
-The most common way to change RuboCop's behaviour is to create a configuration file named `.rubocop.yml` in the
+The most common way to change RbHint's behaviour is to create a configuration file named `.rbhint.yml` in the
 project's root directory.
 
 For more information, see xref:configuration.adoc[Configuration].
 
-== 2. RuboCop as a replacement for `ruby -w`
+== 2. RbHint as a replacement for `ruby -w`
 
-RuboCop natively implements almost all `ruby -w` lint warning checks, and then some. If you want you can use RuboCop
+RbHint natively implements almost all `ruby -w` lint warning checks, and then some. If you want you can use RbHint
 simply as a replacement for `ruby -w`:
 
 [source,sh]
 ----
-$ rubocop -l
+$ rbhint -l
 ----
 
-== 3. RuboCop as a formatter
+== 3. RbHint as a formatter
 
 There's a handy shortcut to run auto-correction only on code layout (a.k.a. formatting) offenses:
 
 [source,sh]
 ----
-$ rubocop -x
+$ rbhint -x
 ----
 
-This option was introduced in RuboCop 0.57.0.
+This option was introduced in RbHint 0.57.0.
 
 == Command-line flags
 
@@ -112,7 +112,7 @@ For more details check the available command-line options:
 
 [source,sh]
 ----
-$ rubocop -h
+$ rbhint -h
 ----
 
 |===
@@ -136,23 +136,23 @@ $ rubocop -h
 | `-d/--debug`
 | Displays some extra debug output.
 
-| `   --disable-pending-cops`
-| Run without pending cops.
+| `   --disable-pending-hints`
+| Run without pending hints.
 
 | `   --disable-uncorrectable`
-| Used with --auto-correct to annotate any offenses that do not support autocorrect with `rubocop:todo` comments.
+| Used with --auto-correct to annotate any offenses that do not support autocorrect with `rbhint:todo` comments.
 
-| `-D/--[no-]display-cop-names`
-| Displays cop names in offense messages. Default is true.
+| `-D/--[no-]display-hint-names`
+| Displays hint names in offense messages. Default is true.
 
 | `   --display-only-fail-level-offenses`
 | Only output offense messages at the specified `--fail-level` or above
 
-| `   --enable-pending-cops`
-| Run with pending cops.
+| `   --enable-pending-hints`
+| Run with pending hints.
 
 | `   --except`
-| Run all cops enabled by configuration except the specified cop(s) and/or departments.
+| Run all hints enabled by configuration except the specified hint(s) and/or departments.
 
 | `   --exclude-limit`
 | Limit how many individual files `--auto-gen-config` can list in `Exclude` parameters, default is 15.
@@ -173,22 +173,22 @@ $ rubocop -h
 | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.
 
 | `   --only-recognized-file-types`
-| Inspect files given on the command line only if they are listed in `AllCops`/`Include` parameters of user configuration or default configuration.
+| Inspect files given on the command line only if they are listed in `AllHints`/`Include` parameters of user configuration or default configuration.
 
 | `-h/--help`
 | Print usage information.
 
 | `   --ignore-parent-exclusion`
-| Ignores all Exclude: settings from all .rubocop.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rubocop settings.
+| Ignores all Exclude: settings from all .rbhint.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rbhint settings.
 
 | `   --init`
-| Generate a .rubocop.yml file in the current directory.
+| Generate a .rbhint.yml file in the current directory.
 
 | `-l/--lint`
-| Run only lint cops.
+| Run only lint hints.
 
 | `-L/--list-target-files`
-| List all files RuboCop will inspect.
+| List all files RbHint will inspect.
 
 | `   --no-auto-gen-timestamp`
 | Don't include the date and time when --auto-gen-config was run in the config file it generates
@@ -197,7 +197,7 @@ $ rubocop -h
 | Don't show offense counts in config file generated by --auto-gen-config
 
 | `   --only`
-| Run only the specified cop(s) and/or cops in the specified departments.
+| Run only the specified hint(s) and/or hints in the specified departments.
 
 | `-o/--out`
 | Write output to a file instead of STDOUT.
@@ -209,16 +209,16 @@ $ rubocop -h
 | Require Ruby file (see link:extensions.md#loading-extensions[Loading Extensions]).
 
 | `   --safe`
-| Run only safe cops.
+| Run only safe hints.
 
 | `   --safe-auto-correct`
-| Omit cops annotated as "not safe". See xref:auto_correct.adoc[Auto-correct].
+| Omit hints annotated as "not safe". See xref:auto_correct.adoc[Auto-correct].
 
-| `   --show-cops`
-| Shows available cops and their configuration.
+| `   --show-hints`
+| Shows available hints and their configuration.
 
 | `-s/--stdin`
-| Pipe source from STDIN. This is useful for editor integration. Takes one argument, a path, relative to the root of the project. RuboCop will use this path to determine which cops are enabled (via eg. Include/Exclude), and so that certain cops like Naming/FileName can be checked.
+| Pipe source from STDIN. This is useful for editor integration. Takes one argument, a path, relative to the root of the project. RbHint will use this path to determine which hints are enabled (via eg. Include/Exclude), and so that certain hints like Naming/FileName can be checked.
 
 | `-x/--fix-layout`
 | Auto-correct only code layout (formatting) offenses.
@@ -230,21 +230,21 @@ $ rubocop -h
 | Displays the current version plus the version of Parser and Ruby.
 |===
 
-Default command-line options are loaded from `.rubocop` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rubocop`.
+Default command-line options are loaded from `.rbhint` and `RBHINT_OPTS` and are combined with command-line options that are explicitly passed to `rbhint`.
 Thus, the options have the following order of precedence (from highest to lowest):
 
 . Explicit command-line options
-. Options from `RUBOCOP_OPTS` environment variable
-. Options from `.rubocop` file.
+. Options from `RBHINT_OPTS` environment variable
+. Options from `.rbhint` file.
 
 == Exit codes
 
-RuboCop exits with the following status codes:
+RbHint exits with the following status codes:
 
 * `0` if no offenses are found or if the severity of all offenses are less than
 `--fail-level`. (By default, if you use `--auto-correct`, offenses which are
-auto-corrected do not cause RuboCop to fail.)
+auto-corrected do not cause RbHint to fail.)
 * `1` if one or more offenses equal or greater to `--fail-level` are found. (By
 default, this is any offense which is not auto-corrected.)
-* `2` if RuboCop terminates abnormally due to invalid configuration, invalid CLI
+* `2` if RbHint terminates abnormally due to invalid configuration, invalid CLI
 options, or an internal error.

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -80,7 +80,7 @@ See xref:usage/auto_correct.adoc[Auto-correct].
 RbHint comes with a preconfigured set of rules for each of its hints, based on the https://rubystyle.guide[Ruby Style Guide].
 Depending on your project, you may wish to reconfigure a hint, tell to ignore certain files, or disable it altogether.
 
-The most common way to change RbHint's behaviour is to create a configuration file named `.rbhint.yml` in the
+The most common way to change RbHint's behaviour is to create a configuration file named `.rubocop.yml` in the
 project's root directory.
 
 For more information, see xref:configuration.adoc[Configuration].
@@ -136,19 +136,19 @@ $ rbhint -h
 | `-d/--debug`
 | Displays some extra debug output.
 
-| `   --disable-pending-hints`
+| `   --disable-pending-cops`
 | Run without pending hints.
 
 | `   --disable-uncorrectable`
-| Used with --auto-correct to annotate any offenses that do not support autocorrect with `rbhint:todo` comments.
+| Used with --auto-correct to annotate any offenses that do not support autocorrect with `rubocop:todo` comments.
 
-| `-D/--[no-]display-hint-names`
+| `-D/--[no-]display-cop-names`
 | Displays hint names in offense messages. Default is true.
 
 | `   --display-only-fail-level-offenses`
 | Only output offense messages at the specified `--fail-level` or above
 
-| `   --enable-pending-hints`
+| `   --enable-pending-cops`
 | Run with pending hints.
 
 | `   --except`
@@ -173,16 +173,16 @@ $ rbhint -h
 | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.
 
 | `   --only-recognized-file-types`
-| Inspect files given on the command line only if they are listed in `AllHints`/`Include` parameters of user configuration or default configuration.
+| Inspect files given on the command line only if they are listed in `AllCops`/`Include` parameters of user configuration or default configuration.
 
 | `-h/--help`
 | Print usage information.
 
 | `   --ignore-parent-exclusion`
-| Ignores all Exclude: settings from all .rbhint.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rbhint settings.
+| Ignores all Exclude: settings from all .rubocop.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's RbHint settings.
 
 | `   --init`
-| Generate a .rbhint.yml file in the current directory.
+| Generate a .rubocop.yml file in the current directory.
 
 | `-l/--lint`
 | Run only lint hints.
@@ -214,7 +214,7 @@ $ rbhint -h
 | `   --safe-auto-correct`
 | Omit hints annotated as "not safe". See xref:auto_correct.adoc[Auto-correct].
 
-| `   --show-hints`
+| `   --show-cops`
 | Shows available hints and their configuration.
 
 | `-s/--stdin`
@@ -230,12 +230,12 @@ $ rbhint -h
 | Displays the current version plus the version of Parser and Ruby.
 |===
 
-Default command-line options are loaded from `.rbhint` and `RBHINT_OPTS` and are combined with command-line options that are explicitly passed to `rbhint`.
+Default command-line options are loaded from `.rubocop.yml` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rbhint`.
 Thus, the options have the following order of precedence (from highest to lowest):
 
 . Explicit command-line options
-. Options from `RBHINT_OPTS` environment variable
-. Options from `.rbhint` file.
+. Options from `RUBOCOP_OPTS` environment variable
+. Options from `.rubocop.yml` file.
 
 == Exit codes
 


### PR DESCRIPTION
Replaced all mentions of `Rubocop` with `RbHint` and `cop` with `hint`.

I think this is still a work in progress as I'm not sure if you all want to commit these kinds of documentation changes incrementally, file by file, or a certain number of files or something else.

Also, I'm not sure how some of the checkboxes below apply to documentation-only changes like this.

I don't think we've settled on which term will replace cop (see #4), so I use `hint` for now.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `development` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/zspencer/rbhint/blob/development/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RbHint for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
