### PR TITLE
Reframe `Metrics/AbcSize` text from `cop` to `hint`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metrics/AbcSize` text from `cop` to `hint`. ([@jdruby]())
 * [#8132](https://github.com/rubocop-hq/rubocop/issues/8132): Fix the problem with `Naming/MethodName: EnforcedStyle: camelCase` and `_` or `i` variables. ([@avrusanov][])
 * [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby]())
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])

--- a/docs/modules/ROOT/pages/cops_metrics.adoc
+++ b/docs/modules/ROOT/pages/cops_metrics.adoc
@@ -12,7 +12,7 @@
 | 0.81
 |===
 
-This cop checks that the ABC size of methods is not higher than the
+This hint checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
 (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
 and https://en.wikipedia.org/wiki/ABC_Software_Metric.

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks that the ABC size of methods is not higher than the
+      # This hint checks that the ABC size of methods is not higher than the
       # configured maximum. The ABC size is based on assignments, branches
       # (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
       # and https://en.wikipedia.org/wiki/ABC_Software_Metric.


### PR DESCRIPTION
I only changed one word here, but I want to make sure this will work for `adoc` document generation before making too many other changes in other `hints`.

If I'm understanding this correctly, [abc_size.rb](https://github.com/zspencer/rbhint/blob/development/lib/rubocop/cop/metrics/abc_size.rb) should match up with the [Metrics/AbcSize section of the documentation](https://docs.rubocop.org/rubocop/0.85/cops_metrics.html#metricsabcsize).

If this is the case, I should be able to go through the `hints` and make similar changes to their text over time.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `development` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/zspencer/rbhint/blob/development/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RbHint for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
