### PR TITLE
[#15] Fix the failing project_spec tests in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4601,3 +4601,4 @@
 [@avrusanov]: https://github.com/avrusanov
 [@mauro-oto]: https://github.com/mauro-oto
 [@jdruby]: https://github.com/jdruby
+[@zspencer]: https://github.com/zspencer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 
 ### Bug fixes
 
-* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metrics/AbcSize` text from `cop` to `hint`. ([@jdruby]())
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metrics/AbcSize` text from `cop` to `hint`. ([@jdruby][])
 * [#8132](https://github.com/rubocop-hq/rubocop/issues/8132): Fix the problem with `Naming/MethodName: EnforcedStyle: camelCase` and `_` or `i` variables. ([@avrusanov][])
-* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby]())
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby][])
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
 * [#8131](https://github.com/rubocop-hq/rubocop/pull/8131): Fix false positive for `Style/RedundantRegexpEscape` with escaped delimiters. ([@owst][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
@@ -28,7 +28,7 @@
 ## 0.85.1 (2020-06-07)
 
 ### Bug fixes
-* [#2](https://github.com/zspencer/rbhint/issues/2): Rename the command line program to `rbhint`
+* [#2](https://github.com/zspencer/rbhint/issues/2): Rename the command line program to `rbhint`. ([@zspencer][])
 * [#8083](https://github.com/rubocop-hq/rubocop/issues/8083): Fix an error for `Lint/MixedRegexpCaptureTypes` cop when using a regular expression that cannot be processed by regexp_parser gem. ([@koic][])
 * [#8081](https://github.com/rubocop-hq/rubocop/issues/8081): Fix a false positive for `Lint/SuppressedException` when empty rescue block in `do` block. ([@koic][])
 * [#8096](https://github.com/rubocop-hq/rubocop/issues/8096): Fix a false positive for `Lint/SuppressedException` when empty rescue block in defs. ([@koic][])

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
         it 'has a valid URL' do
           issues.each do |issue|
             number = issue[:number].gsub(/\D/, '')
-            pattern = %r{^https://github\.com/rubocop-hq/rubocop/(?:issues|pull)/#{number}$}
+            pattern = %r{^https://github\.com/(zspencer/rbhint|rubocop-hq/rubocop)/(?:issues|pull)/#{number}$}
             expect(issue[:url]).to match(pattern)
           end
         end


### PR DESCRIPTION
It turns out there were a number of failures occuring in `spec/project_spec.rb` because we had not conformed to the enforced changelog format. 

This makes the specs that were too stringent a bit looser (allowing issues/pulls from zspencer/rbhint, for example) and updates the content of the CHANGELOG.md file to fix the places where we had gone off the rails.
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `development` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/zspencer/rbhint/blob/development/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RbHint for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
