### PR TITLE
Reframe `Layout/BlockAlignment` text from `cop` to `hint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Layout/BlockAlignment` text from `cop` to `hint`. ([@jdruby][])
 * [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metrics/AbcSize` text from `cop` to `hint`. ([@jdruby][])
 * [#8132](https://github.com/rubocop-hq/rubocop/issues/8132): Fix the problem with `Naming/MethodName: EnforcedStyle: camelCase` and `_` or `i` variables. ([@avrusanov][])
 * [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby][])

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -273,7 +273,7 @@ value =
 | -
 |===
 
-This cop checks whether the end keywords are aligned properly for do
+This hint checks whether the end keywords are aligned properly for do
 end blocks.
 
 Three modes are supported through the `EnforcedStyleAlignWith`

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # This cop checks whether the end keywords are aligned properly for do
+      # This hint checks whether the end keywords are aligned properly for do
       # end blocks.
       #
       # Three modes are supported through the `EnforcedStyleAlignWith`


### PR DESCRIPTION
Another one-word change from `cop` to `hint`. This time, to the `Layout/BlockAlignment` hint text.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `development` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/zspencer/rbhint/blob/development/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RbHint for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
