### PR TITLE
Reframe configuration documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,7 @@
 
 ### Bug fixes
 
-* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Layout/BlockAlignment` text from `cop` to `hint`. ([@jdruby][])
-* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metrics/AbcSize` text from `cop` to `hint`. ([@jdruby][])
 * [#8132](https://github.com/rubocop-hq/rubocop/issues/8132): Fix the problem with `Naming/MethodName: EnforcedStyle: camelCase` and `_` or `i` variables. ([@avrusanov][])
-* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby][])
 * [#8115](https://github.com/rubocop-hq/rubocop/issues/8115): Fix false negative for `Lint::FormatParameterMismatch` when argument contains formatting. ([@andrykonchin][])
 * [#8131](https://github.com/rubocop-hq/rubocop/pull/8131): Fix false positive for `Style/RedundantRegexpEscape` with escaped delimiters. ([@owst][])
 * [#8124](https://github.com/rubocop-hq/rubocop/issues/8124): Fix a false positive for `Lint/FormatParameterMismatch` when using named parameters with escaped `%`. ([@koic][])
@@ -25,6 +22,10 @@
 ### Changes
 
 * [#8146](https://github.com/rubocop-hq/rubocop/pull/8146): Use UTC in RuboCop todo file generation. ([@mauro-oto][])
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Basic Usage documentation to RbHint from Rubocop. ([@jdruby][])
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metrics/AbcSize` text from `cop` to `hint`. ([@jdruby][])
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Layout/BlockAlignment` text from `cop` to `hint`. ([@jdruby][])
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Configuration documentation to RbHint from Rubocop. ([@jdruby][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -34,7 +34,7 @@ dotfile or a config file inside the https://specifications.freedesktop.org/based
 specification].
 
 * `~/.rubocop.yml`
-* `$XDG_CONFIG_HOME/rbhint/config.yml` (expands to `~/.config/rbhint/config.yml`
+* `$XDG_CONFIG_HOME/rubocop/config.yml` (expands to `~/.config/rubocop/config.yml`
 if `$XDG_CONFIG_HOME` is not set)
 
 If both files exist, the dotfile will be selected.
@@ -48,7 +48,7 @@ files:
 * `/path/to/project/.rubocop.yml`
 * `/.rubocop.yml`
 * `~/.rubocop.yml`
-* `~/.config/rbhint/config.yml`
+* `~/.config/rubocop/config.yml`
 * https://github.com/zspencer/rbhint/blob/development/config/default.yml[RbHint's default configuration]
 
 == Inheritance

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,8 +1,8 @@
 = Configuration
 
-The behavior of RuboCop can be controlled via the
+The behavior of RbHint can be controlled via the
 https://github.com/zspencer/rbhint/blob/development/.rubocop.yml[.rubocop.yml]
-configuration file. It makes it possible to enable/disable certain cops
+configuration file. It makes it possible to enable/disable certain hints
 (checks) and to alter their behavior if they accept any parameters. The file
 can be placed in your home directory, XDG config directory, or in some project
 directory.
@@ -20,12 +20,12 @@ Layout/LineLength:
   Max: 99
 ----
 
-NOTE: Qualifying cop name with its type, e.g., `Style`, is recommended,
-but not necessary as long as the cop name is unique across all types.
+NOTE: Qualifying hint name with its type, e.g., `Style`, is recommended,
+but not necessary as long as the hint name is unique across all types.
 
 == Config file locations
 
-RuboCop will start looking for the configuration file in the directory
+RbHint will start looking for the configuration file in the directory
 where the inspected file is and continue its way up to the root directory.
 
 If it cannot be found until reaching the project's root directory, then it will
@@ -34,13 +34,13 @@ dotfile or a config file inside the https://specifications.freedesktop.org/based
 specification].
 
 * `~/.rubocop.yml`
-* `$XDG_CONFIG_HOME/rubocop/config.yml` (expands to `~/.config/rubocop/config.yml`
+* `$XDG_CONFIG_HOME/rbhint/config.yml` (expands to `~/.config/rbhint/config.yml`
 if `$XDG_CONFIG_HOME` is not set)
 
 If both files exist, the dotfile will be selected.
 
-As an example, if RuboCop is invoked from inside `/path/to/project/lib/utils`,
-then RuboCop will use the config as specified inside the first of the following
+As an example, if RbHint is invoked from inside `/path/to/project/lib/utils`,
+then RbHint will use the config as specified inside the first of the following
 files:
 
 * `/path/to/project/lib/utils/.rubocop.yml`
@@ -48,15 +48,15 @@ files:
 * `/path/to/project/.rubocop.yml`
 * `/.rubocop.yml`
 * `~/.rubocop.yml`
-* `~/.config/rubocop/config.yml`
-* https://github.com/zspencer/rbhint/blob/development/config/default.yml[RuboCop's default configuration]
+* `~/.config/rbhint/config.yml`
+* https://github.com/zspencer/rbhint/blob/development/config/default.yml[RbHint's default configuration]
 
 == Inheritance
 
-All configuration inherits from https://github.com/zspencer/rbhint/blob/development/config/default.yml[RuboCop's default configuration] (See
+All configuration inherits from https://github.com/zspencer/rbhint/blob/development/config/default.yml[RbHint's default configuration] (See
 "Defaults").
 
-RuboCop also supports inheritance in user's configuration files. The most common
+RbHint also supports inheritance in user's configuration files. The most common
 example would be the `.rubocop_todo.yml` file (See "Automatically Generated
 Configuration" below).
 
@@ -130,7 +130,7 @@ last one has the highest. The format for multiple inheritance using URLs is:
 [source,yaml]
 ----
 inherit_from:
-  - http://www.example.com/rubocop.yml
+  - http://www.example.com/rbhint.yml
   - ../.rubocop.yml
 ----
 
@@ -138,7 +138,7 @@ inherit_from:
 
 The optional `inherit_gem` directive is used to include configuration from
 one or more gems external to the current project. This makes it possible to
-inherit a shared dependency's RuboCop configuration that can be used from
+inherit a shared dependency's RbHint configuration that can be used from
 multiple disparate projects.
 
 Configurations inherited in this way will be essentially _prepended_ to the
@@ -172,12 +172,12 @@ inherit_gem:
 
 NOTE: If the shared dependency is declared using a https://bundler.io/[Bundler]
 Gemfile and the gem was installed using `bundle install`, it would be
-necessary to also invoke RuboCop using Bundler in order to find the
+necessary to also invoke RbHint using Bundler in order to find the
 dependency's installation path at runtime:
 
 [source,sh]
 ----
-$ bundle exec rubocop <options...>
+$ bundle exec rbhint <options...>
 ----
 
 === Merging arrays using inherit_mode
@@ -218,11 +218,11 @@ Style/For:
     - foo.rb
 ----
 
-The list of ``Exclude``s for the `Style/For` cop in this example will be
+The list of ``Exclude``s for the `Style/For` hint in this example will be
 `['foo.rb', 'bar.rb']`. Similarly, the `AllCops:Exclude` list will contain all
 the default patterns plus the `+generated/**/*.rb+` entry that was added locally.
 
-The directive can also be used on individual cop configurations to override
+The directive can also be used on individual hint configurations to override
 the global setting.
 
 [source,yaml]
@@ -248,7 +248,7 @@ In this example the `Exclude` would only include `bar.rb`.
 
 Configuration files are pre-processed using the ERB templating mechanism. This
 makes it possible to add dynamic content that will be evaluated when the
-configuation file is read. For example, you could let RuboCop ignore all files
+configuation file is read. For example, you could let RbHint ignore all files
 ignored by Git.
 
 [source,yaml]
@@ -262,7 +262,7 @@ AllCops:
 
 == Defaults
 
-The file https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml[config/default.yml] under the RuboCop home directory contains the
+The file https://github.com/zspencer/rbhint/blob/development/config/default.yml[config/default.yml] under the RbHint home directory contains the
 default settings that all configurations inherit from. Project and personal
 `.rubocop.yml` files need only make settings that are different from the
 default ones. If there is no `.rubocop.yml` file in the project, home or XDG
@@ -270,7 +270,7 @@ directories, `config/default.yml` will be used.
 
 == Including/Excluding files
 
-RuboCop does a recursive file search starting from the directory it is
+RbHint does a recursive file search starting from the directory it is
 run in, or directories given as command line arguments. Files that
 match any pattern listed under `AllCops`/`Include` and extensionless
 files with a hash-bang (`#!`) declaration containing one of the known
@@ -296,7 +296,7 @@ AllCops:
 ----
 
 NOTE: When inspecting a certain directory(or file)
-given as RuboCop's command line arguments,
+given as RbHint's command line arguments,
 patterns listed under `AllCops` / `Exclude` are also inspected.
 If you want to apply `AllCops` / `Exclude` rules in this circumstance,
 add `--force-exclusion` to the command line argument.
@@ -311,15 +311,15 @@ AllCops:
     - foo.rb
 ----
 
-If `foo.rb` specified as a RuboCop's command line argument, the result is:
+If `foo.rb` specified as a RbHint's command line argument, the result is:
 
 [source,sh]
 ----
-# RuboCop inspects foo.rb.
-$ bundle exec rubocop foo.rb
+# RbHint inspects foo.rb.
+$ bundle exec rbhint foo.rb
 
-# RuboCop does not inspect foo.rb.
-$ bundle exec rubocop --force-exclusion foo.rb
+# RbHint does not inspect foo.rb.
+$ bundle exec rbhint --force-exclusion foo.rb
 ----
 
 === Path relativity
@@ -328,15 +328,15 @@ In `.rubocop.yml` and any other configuration file beginning with `.rubocop`,
 files, and directories are specified relative to the directory where the
 configuration file is. In configuration files that don't begin with `.rubocop`,
 e.g. `our_company_defaults.yml`, paths are relative to the directory where
-`rubocop` is run.
+`rbhint` is run.
 
 === Unusual files, that would not be included by default
 
-RuboCop comes with a comprehensive list of common ruby file names and
-extensions. But, if you'd like RuboCop to check files that are not included by
+RbHint comes with a comprehensive list of common ruby file names and
+extensions. But, if you'd like RbHint to check files that are not included by
 default, you'll need to pass them in on the command line, or to add entries for
 them under `AllCops`/`Include`. Remember that your configuration files override
-https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml[RuboCops's defaults]. In the following example, we want to include
+https://github.com/zspencer/rbhint/blob/development/config/default.yml[RbHint's defaults]. In the following example, we want to include
 `foo.unusual_extension`, but we also must copy any other patterns we need from
 the overridden `default.yml`.
 
@@ -355,7 +355,7 @@ AllCops:
 ----
 
 This behavior of `Include` (overriding `default.yml`) was introduced in
-https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0560-2018-05-14[0.56.0]
+https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md#0560-2018-05-14[0.56.0]
 via https://github.com/rubocop-hq/rubocop/pull/5882[#5882]. This change allows
 people to include/exclude precisely what they need to, without the defaults
 getting in the way.
@@ -392,16 +392,16 @@ The `Include` and `Exclude` parameters are special. They are
 valid for the directory tree starting where they are defined. They are not
 shadowed by the setting of `Include` and `Exclude` in other `.rubocop.yml`
 files in subdirectories. This is different from all other parameters, who
-follow RuboCop's general principle that configuration for an inspected file
+follow RbHint's general principle that configuration for an inspected file
 is taken from the nearest `.rubocop.yml`, searching upwards. _This behavior
 will be overridden if you specify the `--ignore-parent-exclusion` command line
 argument_.
 
-=== Cop-specific `Include` and `Exclude`
+=== Hint-specific `Include` and `Exclude`
 
-Cops can be run only on specific sets of files when that's needed (for
+Hints can be run only on specific sets of files when that's needed (for
 instance you might want to run some Rails model checks only on files whose
-paths match `app/models/*.rb`). All cops support the
+paths match `app/models/*.rb`). All hints support the
 `Include` param.
 
 [source,yaml]
@@ -411,8 +411,8 @@ Rails/HasAndBelongsToMany:
     - app/models/*.rb
 ----
 
-Cops can also exclude only specific sets of files when that's needed (for
-instance you might want to run some cop only on a specific file). All cops support the
+Hints can also exclude only specific sets of files when that's needed (for
+instance you might want to run some hint only on a specific file). All hints support the
 `Exclude` param.
 
 [source,yaml]
@@ -425,11 +425,11 @@ Rails/HasAndBelongsToMany:
 == Generic configuration parameters
 
 In addition to `Include` and `Exclude`, the following parameters are available
-for every cop.
+for every hint.
 
 === Enabled
 
-Specific cops can be disabled by setting `Enabled` to `false` for that specific cop.
+Specific hints can be disabled by setting `Enabled` to `false` for that specific hint.
 
 [source,yaml]
 ----
@@ -437,11 +437,11 @@ Layout/LineLength:
   Enabled: false
 ----
 
-Most cops are enabled by default. Cops, introduced or significantly updated
+Most hints are enabled by default. Hints, introduced or significantly updated
 between major versions, are in a special pending status (read more in
-xref:versioning.adoc["Versioning"]). Some cops, configured the above `Enabled: false`
-in https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml[config/default.yml],
-are disabled by default. The cop enabling process can be altered by
+xref:versioning.adoc["Versioning"]). Some hints, configured the above `Enabled: false`
+in https://github.com/zspencer/rbhint/blob/development/config/default.yml[config/default.yml],
+are disabled by default. The hint enabling process can be altered by
 setting `DisabledByDefault` or `EnabledByDefault` (but not both) to `true`.
 
 [source,yaml]
@@ -450,10 +450,10 @@ AllCops:
   DisabledByDefault: true
 ----
 
-All cops are then disabled by default. Only cops appearing in user
+All hints are then disabled by default. Only hints appearing in user
 configuration files are enabled. `Enabled: true` does not have to be
-set for cops in user configuration. They will be enabled anyway. It is also
-possible to enable entire departments by adding for example
+set for hints in user configuration. They will be enabled anyway. It is also
+possible to enable entire categories by adding for example
 
 [source,yaml]
 ----
@@ -461,16 +461,16 @@ Style:
   Enabled: true
 ----
 
-All cops are then enabled by default. Only cops explicitly disabled
+All hints are then enabled by default. Only hints explicitly disabled
 using `Enabled: false` in user configuration files are disabled.
 
-If a department is disabled, cops in that department can still be individually
-enabled, and that setting overrides the setting for its department in the same
+If a category is disabled, hints in that category can still be individually
+enabled, and that setting overrides the setting for its category in the same
 configuration file and in any inherited file.
 
 [source,yaml]
 ----
-inherit_from: config_that_disables_the_metrics_department.yml
+inherit_from: config_that_disables_the_metrics_category.yml
 
 Metrics/MethodLength:
   Enabled: true
@@ -484,14 +484,14 @@ Style/Alias:
 
 === Severity
 
-Each cop has a default severity level based on which department it belongs
+Each hint has a default severity level based on which category it belongs
 to. The level is normally `warning` for `Lint` and `convention` for all the
-others, but this can be changed in user configuration. Cops can customize their
+others, but this can be changed in user configuration. Hints can customize their
 severity level. Allowed values are `refactor`, `convention`, `warning`, `error`
 and `fatal`.
 
 There is one exception from the general rule above and that is `Lint/Syntax`, a
-special cop that checks for syntax errors before the other cops are invoked. It
+special hint that checks for syntax errors before the other hints are invoked. It
 cannot be disabled and its severity (`fatal`) cannot be changed in
 configuration.
 
@@ -506,7 +506,7 @@ Metrics/CyclomaticComplexity:
 
 === Details
 
-Individual cops can be embellished with extra details in offense messages:
+Individual hints can be embellished with extra details in flag messages:
 
 [source,yaml]
 ----
@@ -519,11 +519,11 @@ Layout/LineLength:
     compromise.
 ----
 
-These details will only be seen when RuboCop is run with the `--extra-details` flag or if `ExtraDetails` is set to true in your global RuboCop configuration.
+These details will only be seen when RbHint is run with the `--extra-details` flag or if `ExtraDetails` is set to true in your global RbHint configuration.
 
 === AutoCorrect
 
-Cops that support the `--auto-correct` option can have that support
+Hints that support the `--auto-correct` option can have that support
 disabled. For example:
 
 [source,yaml]
@@ -539,7 +539,7 @@ inspected code must run on. For example, enforcing using Ruby 2.6+ endless
 ranges `foo[n..]` rather than `foo[n..-1]` can help make your code shorter and
 more consistent... _unless_ it must run on e.g. Ruby 2.5.
 
-Users may let RuboCop know the oldest version of Ruby which your project
+Users may let RbHint know the oldest version of Ruby which your project
 supports with:
 
 [source,yaml]
@@ -548,49 +548,49 @@ AllCops:
   TargetRubyVersion: 2.5
 ----
 
-Otherwise, RuboCop will then check your project for `.ruby-version` and
+Otherwise, RbHint will then check your project for `.ruby-version` and
 use the version specified by it.
 
 == Automatically Generated Configuration
 
-If you have a code base with an overwhelming amount of offenses, it can
-be a good idea to use `rubocop --auto-gen-config`, which creates
+If you have a code base with an overwhelming amount of flags, it can
+be a good idea to use `rbhint --auto-gen-config`, which creates
 `.rubocop_todo.yml` and adds `inherit_from: .rubocop_todo.yml` in your
 `.rubocop.yml`. The generated file `.rubocop_todo.yml` contains
-configuration to disable cops that currently detect an offense in the
-code by changing the configuration for the cop, excluding the offending
-files, or disabling the cop altogether once a file count limit has been
+configuration to disable hints that currently detect a flag in the
+code by changing the configuration for the hint, excluding the offending
+files, or disabling the hint altogether once a file count limit has been
 reached.
 
-By adding the option `--exclude-limit COUNT`, e.g., `rubocop
+By adding the option `--exclude-limit COUNT`, e.g., `rbhint
 --auto-gen-config --exclude-limit 5`, you can change how many files are
-excluded before the cop is entirely disabled. The default COUNT is 15.
+excluded before the hint is entirely disabled. The default COUNT is 15.
 
 The next step is to cut and paste configuration from `.rubocop_todo.yml`
 into `.rubocop.yml` for everything that you think is in line with your
 (organization's) code style and not a good fit for a todo list. Pay
 attention to the comments above each entry. They can reveal configuration
 parameters such as `EnforcedStyle`, which can be used to modify the
-behavior of a cop instead of disabling it completely.
+behavior of a hint instead of disabling it completely.
 
 Then you can start removing the entries in the generated
-`.rubocop_todo.yml` file one by one as you work through all the offenses
+`.rubocop_todo.yml` file one by one as you work through all the flags
 in the code.
 
-Another way of silencing offense reports, aside from configuration, is
+Another way of silencing flag reports, aside from configuration, is
 through source code comments. These can be added manually or
-automatically. See "Disabling Cops within Source Code" below.
+automatically. See "Disabling Hints within Source Code" below.
 
-The cops in the `Metrics` department will by default get `Max` parameters
+The hints in the `Metrics` category will by default get `Max` parameters
 generated in `.rubocop_todo.yml`. The value of these will be just high enough
-so that no offenses are reported the next time you run `rubocop`. If you
-prefer to exclude files, like for other cops, add `--auto-gen-only-exclude`
+so that no flags are reported the next time you run `rbhint`. If you
+prefer to exclude files, like for other hints, add `--auto-gen-only-exclude`
 when running with `--auto-gen-config`. It will still change the maximum if the
 number of excluded files is higher than the exclude limit.
 
 == Updating the configuration file
 
-When you update RuboCop version, sometimes you need to change `.rubocop.yml`.
+When you update RbHint version, sometimes you need to change `.rubocop.yml`.
 If you use https://github.com/pocke/mry[mry], you can update `.rubocop.yml`
 to latest version automatically.
 
@@ -605,9 +605,9 @@ $ mry --target=0.48.0 .rubocop.yml
 
 See https://github.com/pocke/mry for more information.
 
-== Disabling Cops within Source Code
+== Disabling Hints within Source Code
 
-One or more individual cops can be disabled locally in a section of a
+One or more individual hints can be disabled locally in a section of a
 file by adding a comment such as
 
 [source,ruby]
@@ -617,7 +617,7 @@ file by adding a comment such as
 # rubocop:enable Layout/LineLength, Style/StringLiterals
 ----
 
-You can also disable _all_ cops with
+You can also disable _all_ hints with
 
 [source,ruby]
 ----
@@ -626,7 +626,7 @@ You can also disable _all_ cops with
 # rubocop:enable all
 ----
 
-In cases where you want to differentiate intentionally-disabled cops vs. cops
+In cases where you want to differentiate intentionally-disabled hints vs. hints
 you'd like to revisit later, you can use `rubocop:todo` as an alias of
 `rubocop:disable`.
 
@@ -637,7 +637,7 @@ you'd like to revisit later, you can use `rubocop:todo` as an alias of
 # rubocop:enable Layout/LineLength, Style/StringLiterals
 ----
 
-One or more cops can be disabled on a single line with an end-of-line
+One or more hints can be disabled on a single line with an end-of-line
 comment.
 
 [source,ruby]
@@ -645,7 +645,7 @@ comment.
 for x in (0..19) # rubocop:disable Style/For
 ----
 
-If you want to disable a cop that inspects comments, you can do so by
+If you want to disable a hint that inspects comments, you can do so by
 adding an "inner comment" on the comment line.
 
 [source,ruby]
@@ -653,11 +653,11 @@ adding an "inner comment" on the comment line.
 # coding: utf-8 # rubocop:disable Style/Encoding
 ----
 
-Running `rubocop --[safe-]auto-correct --disable-uncorrectable` will
-create comments to disable all offenses that can't be automatically
+Running `rbhint --[safe-]auto-correct --disable-uncorrectable` will
+create comments to disable all flags that can't be automatically
 corrected.
 
-Do not write anything other than cop name in the disabling comment. E.g.:
+Do not write anything other than hint name in the disabling comment. E.g.:
 
 [source,ruby]
 ----
@@ -667,7 +667,7 @@ Do not write anything other than cop name in the disabling comment. E.g.:
 == Setting the style guide URL
 
 You can specify the base URL of the style guide using `StyleGuideBaseURL`.
-If specified under `AllCops`, all cops are targeted.
+If specified under `AllCops`, all hints are targeted.
 
 [source,yaml]
 ----
@@ -675,7 +675,7 @@ AllCops:
   StyleGuideBaseURL: https://rubystyle.guide
 ----
 
-`StyleGuideBaseURL` is combined with `StyleGuide` specified to the cop.
+`StyleGuideBaseURL` is combined with `StyleGuide` specified to the hint.
 
 [source,yaml]
 ----
@@ -685,8 +685,8 @@ Lint/UselessAssignment:
 
 The style guide URL is https://rubystyle.guide#underscore-unused-vars.
 
-If specified under a specific department, it takes precedence over `AllCops`.
-The following is an example of specifying `Rails` department.
+If specified under a specific category, it takes precedence over `AllCops`.
+The following is an example of specifying `Rails` category.
 
 [source,yaml]
 ----


### PR DESCRIPTION
This reframes `configuration.adoc`.

I changed all occurrences of each of the following:
`cop` --> `hint`
`rubocop` --> `rbhint`
`offense` --> `flag`
`department` --> `category`

I tried not to change anything that referred directly to a command, flag, or file that may still reference rubocop.

Related to issue #4.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `development` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/zspencer/rbhint/blob/development/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RbHint for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
