### PR TITLE
Reframe `Metric` cops text from `cop` to `hint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Layout/BlockAlignment` text from `cop` to `hint`. ([@jdruby][])
 * [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Layout` cops text from `cop` to `hint`. ([@jdruby][])
 * [#4](https://github.com/zspencer/rbhint/issues/4): Reframe the Configuration documentation to RbHint from Rubocop. ([@jdruby][])
+* [#4](https://github.com/zspencer/rbhint/issues/4): Reframe `Metric` cops text from `cop` to `hint`. ([@jdruby][])
 
 ## 0.85.1 (2020-06-07)
 

--- a/docs/modules/ROOT/pages/cops_metrics.adoc
+++ b/docs/modules/ROOT/pages/cops_metrics.adoc
@@ -48,10 +48,10 @@ and https://en.wikipedia.org/wiki/ABC_Software_Metric.
 | 0.66
 |===
 
-This cop checks if the length of a block exceeds some maximum value.
+This hint checks if the length of a block exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
-The cop can be configured to ignore blocks passed to certain methods.
+The hint can be configured to ignore blocks passed to certain methods.
 
 === Configurable attributes
 
@@ -87,7 +87,7 @@ The cop can be configured to ignore blocks passed to certain methods.
 | 0.47
 |===
 
-This cop checks for excessive nesting of conditional and looping
+This hint checks for excessive nesting of conditional and looping
 constructs.
 
 You can configure if blocks are considered using the `CountBlocks`
@@ -126,7 +126,7 @@ The maximum level of nesting allowed is configurable.
 | -
 |===
 
-This cop checks if the length a class exceeds some maximum value.
+This hint checks if the length a class exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 
@@ -156,7 +156,7 @@ The maximum allowed length is configurable.
 | 0.81
 |===
 
-This cop checks that the cyclomatic complexity of methods is not higher
+This hint checks that the cyclomatic complexity of methods is not higher
 than the configured maximum. The cyclomatic complexity is the number of
 linearly independent paths through a method. The algorithm counts
 decision points and adds one.
@@ -209,7 +209,7 @@ Blocks that are calls to builtin iteration methods
 | 0.59.2
 |===
 
-This cop checks if the length of a method exceeds some maximum value.
+This hint checks if the length of a method exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 
@@ -247,7 +247,7 @@ The maximum allowed length is configurable.
 | -
 |===
 
-This cop checks if the length a module exceeds some maximum value.
+This hint checks if the length a module exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 
@@ -277,7 +277,7 @@ The maximum allowed length is configurable.
 | -
 |===
 
-This cop checks for methods with too many parameters.
+This hint checks for methods with too many parameters.
 The maximum number of parameters is configurable.
 Keyword arguments can optionally be excluded from the total count.
 
@@ -311,13 +311,13 @@ Keyword arguments can optionally be excluded from the total count.
 | 0.81
 |===
 
-This cop tries to produce a complexity score that's a measure of the
+This hint tries to produce a complexity score that's a measure of the
 complexity the reader experiences when looking at a method. For that
 reason it considers `when` nodes as something that doesn't add as much
 complexity as an `if` or a `&&`. Except if it's one of those special
 `case`/`when` constructs where there's no expression after `case`. Then
-the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
-nodes count. In contrast to the CyclomaticComplexity cop, this cop
+the hint treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
+nodes count. In contrast to the CyclomaticComplexity hint, this hint
 considers `else` nodes as adding complexity.
 
 === Examples

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -3,10 +3,10 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length of a block exceeds some maximum value.
+      # This hint checks if the length of a block exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
-      # The cop can be configured to ignore blocks passed to certain methods.
+      # The hint can be configured to ignore blocks passed to certain methods.
       class BlockLength < Cop
         include TooManyLines
 

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks for excessive nesting of conditional and looping
+      # This hint checks for excessive nesting of conditional and looping
       # constructs.
       #
       # You can configure if blocks are considered using the `CountBlocks`

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length a class exceeds some maximum value.
+      # This hint checks if the length a class exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       class ClassLength < Cop

--- a/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
+++ b/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks that the cyclomatic complexity of methods is not higher
+      # This hint checks that the cyclomatic complexity of methods is not higher
       # than the configured maximum. The cyclomatic complexity is the number of
       # linearly independent paths through a method. The algorithm counts
       # decision points and adds one.

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length of a method exceeds some maximum value.
+      # This hint checks if the length of a method exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       class MethodLength < Cop

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks if the length a module exceeds some maximum value.
+      # This hint checks if the length a module exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       class ModuleLength < Cop

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop checks for methods with too many parameters.
+      # This hint checks for methods with too many parameters.
       # The maximum number of parameters is configurable.
       # Keyword arguments can optionally be excluded from the total count.
       class ParameterLists < Cop

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -3,13 +3,13 @@
 module RuboCop
   module Cop
     module Metrics
-      # This cop tries to produce a complexity score that's a measure of the
+      # This hint tries to produce a complexity score that's a measure of the
       # complexity the reader experiences when looking at a method. For that
       # reason it considers `when` nodes as something that doesn't add as much
       # complexity as an `if` or a `&&`. Except if it's one of those special
       # `case`/`when` constructs where there's no expression after `case`. Then
-      # the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
-      # nodes count. In contrast to the CyclomaticComplexity cop, this cop
+      # the hint treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
+      # nodes count. In contrast to the CyclomaticComplexity hint, this hint
       # considers `else` nodes as adding complexity.
       #
       # @example


### PR DESCRIPTION
This reframes the text of all of the Metric cops to hints for use in the documentation.

Related to issue #4.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `development` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/zspencer/rbhint/blob/development/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/zspencer/rbhint/blob/development/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RbHint for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
